### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+Unfurl is a client-side dialog/story file editor (React + Vite + Electron). No databases or backend services are required.
+
+### Running the app
+
+- `npm run dev` starts both the Vite dev server (web) and an Electron window. In headless/cloud environments, the Electron process will emit GPU/D-Bus errors but the Vite web server still serves the app at `http://localhost:5173/`.
+- `npm run build` runs `tsc && vite build` (type-check then bundle).
+- `npm run lint` runs ESLint on `src/`. The codebase has 2 pre-existing warnings (`react-hooks/exhaustive-deps`); `--max-warnings 0` causes a non-zero exit.
+
+### Testing
+
+There are no automated test suites in this project. Verify changes by running `npx tsc --noEmit` (type-check) and `npm run lint` (linting). For UI changes, run `npm run dev` and manually test in the browser.
+
+### Sample data
+
+`public/Lorcan02.1.twee` is a sample Twee dialog file that can be imported via the app's upload UI to verify the graph editor works end-to-end.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- Overview of the project (client-side React + Vite + Electron dialog editor)
- Notes on running `npm run dev` in headless environments (Electron errors are expected, web server works fine)
- Lint and type-check commands
- Note about the 2 pre-existing ESLint warnings
- Sample data location for manual testing

### Demo

[unfurl_dialog_editor_demo.mp4](https://cursor.com/agents/bc-21740d5d-5dbd-45be-81bb-2988a5f2d558/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funfurl_dialog_editor_demo.mp4)

The Unfurl dialog editor running in dev mode: importing a `.twee` file, viewing the dialog graph, and clicking nodes to inspect content.

[Dialog tree graph visualization](https://cursor.com/agents/bc-21740d5d-5dbd-45be-81bb-2988a5f2d558/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funfurl_dialog_tree.webp)
[Node details panel showing dialogue content](https://cursor.com/agents/bc-21740d5d-5dbd-45be-81bb-2988a5f2d558/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Funfurl_node_details.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21740d5d-5dbd-45be-81bb-2988a5f2d558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21740d5d-5dbd-45be-81bb-2988a5f2d558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

