### PR TITLE
Add TanStack Router editable file history

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-router": "^1.170.4",
     "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-router':
+        specifier: ^1.170.4
+        version: 1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@xyflow/react':
         specifier: ^12.10.2
         version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1117,6 +1120,30 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/react-router@1.170.4':
+    resolution: {integrity: sha512-cusL4YCTuGGJhjfsXEBm6/SmOAs/G8wRVNadeyN3ofu4OZwX69KAybBEf217buxYzI+FohdJVoigEpJV+tGzIw==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.2':
+    resolution: {integrity: sha512-sUd+BhGYkBF64LVhmOHnYsc1AutPNch/huohEXiXL4IUgmk17Gy+RkUazvjQhptVdYW5QT+qtATrUr2cQZNHFA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1601,6 +1628,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -2173,6 +2203,10 @@ packages:
   isbinaryfile@5.0.7:
     resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
     engines: {node: '>= 18.0.0'}
+
+  isbot@5.1.40:
+    resolution: {integrity: sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2751,6 +2785,16 @@ packages:
 
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
   shebang-command@2.0.0:
@@ -4171,6 +4215,33 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.13(@types/node@25.9.0)(jiti@2.7.0)
 
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/react-router@1.170.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.171.2
+      isbot: 5.1.40
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
+  '@tanstack/router-core@1.171.2':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4752,6 +4823,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   core-util-is@1.0.2:
     optional: true
@@ -5409,6 +5482,8 @@ snapshots:
 
   isbinaryfile@5.0.7: {}
 
+  isbot@5.1.40: {}
+
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
@@ -5943,6 +6018,12 @@ snapshots:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "@/app/app";
 
 vi.mock("@tanstack/react-router", () => ({
-  Outlet: () => <main data-testid="route-outlet" />,
+  Outlet: () => <div data-testid="route-outlet" />,
 }));
 
 vi.mock("@/features/recent-files", () => ({
@@ -23,6 +23,7 @@ describe("App shell", () => {
     expect(
       screen.getByRole("button", { name: /toggle editable files sidebar/i }),
     ).toBeInTheDocument();
+    expect(screen.getAllByRole("main")).toHaveLength(1);
     expect(
       screen.getByRole("navigation", { name: /editable files/i }),
     ).toBeInTheDocument();

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -34,6 +34,10 @@ describe("App shell", () => {
     render(<App />);
 
     expect(screen.getByRole("banner")).toHaveTextContent("Unfurl");
+    expect(screen.getByRole("banner")).toHaveClass(
+      "electron-titlebar-drag-region",
+    );
+    expect(screen.getByRole("banner")).not.toHaveClass("draggable");
     expect(
       screen.getByRole("navigation", { name: /editable files/i }),
     ).toBeInTheDocument();

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import App from "@/app/app";
+
+vi.mock("@tanstack/react-router", () => ({
+  Outlet: () => <main data-testid="route-outlet" />,
+}));
+
+vi.mock("@/features/recent-files", () => ({
+  RecentFilesSidebar: () => <nav aria-label="Editable files" />,
+}));
+
+describe("App shell", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, "ipcRenderer");
+  });
+
+  it("does not render Electron navigation chrome in the web view", () => {
+    render(<App />);
+
+    expect(screen.queryByRole("banner")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("navigation", { name: /editable files/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders Electron navigation chrome in the Electron app view", () => {
+    Object.defineProperty(window, "ipcRenderer", {
+      configurable: true,
+      value: { on: vi.fn() },
+    });
+
+    render(<App />);
+
+    expect(screen.getByRole("banner")).toHaveTextContent("Unfurl");
+    expect(
+      screen.getByRole("navigation", { name: /editable files/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -21,6 +21,9 @@ describe("App shell", () => {
 
     expect(screen.queryByRole("banner")).not.toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: /toggle editable files sidebar/i }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("navigation", { name: /editable files/i }),
     ).toBeInTheDocument();
   });

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -16,13 +16,13 @@ describe("App shell", () => {
     Reflect.deleteProperty(window, "ipcRenderer");
   });
 
-  it("does not render Electron navigation chrome in the web view", () => {
+  it("does not render the Electron titlebar in the web view", () => {
     render(<App />);
 
     expect(screen.queryByRole("banner")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("navigation", { name: /editable files/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("navigation", { name: /editable files/i }),
+    ).toBeInTheDocument();
   });
 
   it("renders Electron navigation chrome in the Electron app view", () => {

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -3,18 +3,16 @@ import { Outlet } from "@tanstack/react-router";
 import { useKeyboardShortcut } from "@/shared/hooks";
 import { EveryWhereDialog } from "@/shared/components";
 import { useDialogStore } from "@/shared/stores";
-import { useFaqModal } from "@/features/faq";
 import { RecentFilesSidebar } from "@/features/recent-files";
+import { useFaqModal } from "@/features/faq";
 
-const isOnlineHost = () =>
-  typeof location !== "undefined" &&
-  location.hostname.includes(".vercel.app") &&
-  location.hostname.includes("unfurl");
+const isElectronRenderer = () =>
+  typeof window !== "undefined" && Boolean(window.ipcRenderer);
 
 const App = () => {
   const setContent = useDialogStore((state) => state.setContent);
   const faqModal = useFaqModal();
-  const isOnline = isOnlineHost();
+  const isElectron = isElectronRenderer();
 
   useKeyboardShortcut(() => setContent(faqModal), {
     codes: ["KeyC", "KeyF"],
@@ -23,13 +21,13 @@ const App = () => {
 
   return (
     <>
-      {!isOnline ? (
+      {isElectron ? (
         <header className="draggable z-50 flex items-center bg-[#3d3d3d] px-3">
           <span className="text-base font-medium">Unfurl</span>
         </header>
       ) : null}
       <div className="flex min-h-screen w-full">
-        <RecentFilesSidebar />
+        {isElectron ? <RecentFilesSidebar /> : null}
         <div className="min-w-0 flex-1">
           <Outlet />
         </div>

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -5,6 +5,11 @@ import { EveryWhereDialog } from "@/shared/components";
 import { useDialogStore } from "@/shared/stores";
 import { RecentFilesSidebar } from "@/features/recent-files";
 import { useFaqModal } from "@/features/faq";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/shared/ui/sidebar";
 
 const isElectronRenderer = () =>
   typeof window !== "undefined" && Boolean(window.ipcRenderer);
@@ -26,12 +31,15 @@ const App = () => {
           <span className="text-base font-medium">Unfurl</span>
         </header>
       ) : null}
-      <div className="flex min-h-screen w-full">
+      <SidebarProvider>
         <RecentFilesSidebar />
-        <div className="min-w-0 flex-1">
+        <SidebarInset className="min-w-0">
+          <div className="fixed left-2 top-2 z-40">
+            <SidebarTrigger aria-label="Toggle editable files sidebar" />
+          </div>
           <Outlet />
-        </div>
-      </div>
+        </SidebarInset>
+      </SidebarProvider>
       <EveryWhereDialog />
     </>
   );

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -22,7 +22,7 @@ const App = () => {
   return (
     <>
       {isElectron ? (
-        <header className="draggable z-50 flex items-center bg-[#3d3d3d] px-3">
+        <header className="electron-titlebar-drag-region z-50 flex items-center bg-[#3d3d3d] px-3">
           <span className="text-base font-medium">Unfurl</span>
         </header>
       ) : null}

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,23 +1,10 @@
-import { Loader2 } from "lucide-react";
+import { Outlet } from "@tanstack/react-router";
 
-import unfurlLogo from "@/assets/unfurl-logo.png";
-import ItchIoLogo from "@/assets/itchio-logo.svg";
 import { useKeyboardShortcut } from "@/shared/hooks";
 import { EveryWhereDialog } from "@/shared/components";
-import {
-  useDialogStore,
-  useJsonDataStore,
-  useNodeStore,
-} from "@/shared/stores";
-import { Button } from "@/shared/ui/button";
-
-import { DemoButton } from "@/features/demo";
-import { DialogViewer } from "@/features/dialog-viewer";
-import { DownloadButton } from "@/features/download";
+import { useDialogStore } from "@/shared/stores";
 import { useFaqModal } from "@/features/faq";
-import { FileUpload } from "@/features/file-upload";
-import { MetadataConfig } from "@/features/metadata-config";
-import { NodeEditor } from "@/features/node-editor";
+import { RecentFilesSidebar } from "@/features/recent-files";
 
 const isOnlineHost = () =>
   typeof location !== "undefined" &&
@@ -25,9 +12,6 @@ const isOnlineHost = () =>
   location.hostname.includes("unfurl");
 
 const App = () => {
-  const name = useJsonDataStore((state) => state.name);
-  const isLoading = useJsonDataStore((state) => state.isLoading);
-  const node = useNodeStore((state) => state.node);
   const setContent = useDialogStore((state) => state.setContent);
   const faqModal = useFaqModal();
   const isOnline = isOnlineHost();
@@ -44,64 +28,12 @@ const App = () => {
           <span className="text-base font-medium">Unfurl</span>
         </header>
       ) : null}
-      <img
-        src={unfurlLogo}
-        alt="Unfurl logo"
-        aria-label="logo"
-        className="mx-auto h-32 p-6 transition-[filter] duration-300 [will-change:filter] hover:[filter:drop-shadow(0_0_2em_#646cffaa)]"
-      />
-      <main className="flex flex-col items-center justify-center gap-4">
-        <h1 className="text-4xl font-bold">
-          Unfurl{isOnline ? " Online" : ""}
-        </h1>
-        <h2 className="box-content flex h-[27px] flex-row justify-center text-2xl">
-          <span className="overflow-hidden">
-            <span className="rotator-span">Twee</span>
-            <span className="rotator-span">Obsidian</span>
-            <span className="rotator-span">md</span>
-            <span className="rotator-span">JSON</span>
-            <span className="rotator-span">Twee</span>
-          </span>
-          <span className="ml-2">Convertor & Editor</span>
-        </h2>
-        {name === "" ? (
-          <FileUpload />
-        ) : (
-          <Button variant="secondary" onClick={() => location.reload()}>
-            Upload another file
-          </Button>
-        )}
-        <section className="mx-auto flex w-[80vw] flex-row items-start justify-evenly py-4">
-          {name !== "" ? (
-            <>
-              <DialogViewer />
-              {node ? <NodeEditor /> : null}
-            </>
-          ) : isLoading ? (
-            <Loader2 className="animate-spin" />
-          ) : null}
-        </section>
-        <section className="flex flex-col items-center gap-4 pb-8">
-          {name !== "" ? <DownloadButton /> : <MetadataConfig />}
-          <DemoButton />
-          {isOnline ? (
-            <Button asChild variant="secondary">
-              <a
-                href="https://hit-box38.itch.io/unfurl"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-2"
-              >
-                <ItchIoLogo />
-                <span>Get the Desktop version</span>
-              </a>
-            </Button>
-          ) : null}
-          <Button variant="info" onClick={() => setContent(faqModal)}>
-            FAQ
-          </Button>
-        </section>
-      </main>
+      <div className="flex min-h-screen w-full">
+        <RecentFilesSidebar />
+        <div className="min-w-0 flex-1">
+          <Outlet />
+        </div>
+      </div>
       <EveryWhereDialog />
     </>
   );

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -27,7 +27,7 @@ const App = () => {
         </header>
       ) : null}
       <div className="flex min-h-screen w-full">
-        {isElectron ? <RecentFilesSidebar /> : null}
+        <RecentFilesSidebar />
         <div className="min-w-0 flex-1">
           <Outlet />
         </div>

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,7 +1,8 @@
 import React, { Suspense } from "react";
 import ReactDOM from "react-dom/client";
+import { RouterProvider } from "@tanstack/react-router";
 
-import App from "@/app/app";
+import { router } from "@/app/router";
 import "@/styles/index.css";
 
 const rootElement = document.getElementById("root");
@@ -12,7 +13,7 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <Suspense>
-      <App />
+      <RouterProvider router={router} />
     </Suspense>
   </React.StrictMode>,
 );

--- a/src/app/pages.tsx
+++ b/src/app/pages.tsx
@@ -135,7 +135,7 @@ export const FilePage = () => {
     );
   }
 
-  if (!fileId || activeFileId !== fileId || name === "") {
+  if (!fileId || activeFileId !== fileId) {
     return (
       <main className="flex min-h-screen items-center justify-center">
         <Loader2 className="animate-spin" aria-label="Loading editable file" />
@@ -150,7 +150,7 @@ export const FilePage = () => {
           <p className="text-sm uppercase tracking-wide text-muted-foreground">
             Editing
           </p>
-          <h1 className="text-3xl font-bold">{name}</h1>
+          <h1 className="text-3xl font-bold">{name || "Untitled"}</h1>
         </div>
         <Button asChild variant="secondary">
           <Link to="/">Upload another file</Link>

--- a/src/app/pages.tsx
+++ b/src/app/pages.tsx
@@ -64,7 +64,7 @@ export const HomePage = ({ isOnline }: PageProps) => {
   }, [resetJson, setSelectedNode]);
 
   return (
-    <main className="flex flex-col items-center justify-center gap-4 p-6">
+    <div className="flex flex-col items-center justify-center gap-4 p-6">
       <EmptyAppHero isOnline={isOnline} />
       <FileUpload />
       <section className="flex flex-col items-center gap-4 pb-8">
@@ -87,7 +87,7 @@ export const HomePage = ({ isOnline }: PageProps) => {
           FAQ
         </Button>
       </section>
-    </main>
+    </div>
   );
 };
 
@@ -117,7 +117,7 @@ export const FilePage = () => {
 
   if (isMissing) {
     return (
-      <main className="flex min-h-screen items-center justify-center p-6">
+      <div className="flex min-h-screen items-center justify-center p-6">
         <Card className="max-w-md text-left">
           <CardHeader>
             <CardTitle>File not found</CardTitle>
@@ -131,20 +131,20 @@ export const FilePage = () => {
             </Button>
           </CardContent>
         </Card>
-      </main>
+      </div>
     );
   }
 
   if (!fileId || activeFileId !== fileId) {
     return (
-      <main className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-screen items-center justify-center">
         <Loader2 className="animate-spin" aria-label="Loading editable file" />
-      </main>
+      </div>
     );
   }
 
   return (
-    <main className="flex flex-col items-center justify-center gap-4 p-6">
+    <div className="flex flex-col items-center justify-center gap-4 p-6">
       <div className="flex w-full max-w-6xl items-center justify-between gap-4">
         <div className="text-left">
           <p className="text-sm uppercase tracking-wide text-muted-foreground">
@@ -164,6 +164,6 @@ export const FilePage = () => {
         <DownloadButton />
         <DemoButton />
       </section>
-    </main>
+    </div>
   );
 };

--- a/src/app/pages.tsx
+++ b/src/app/pages.tsx
@@ -1,0 +1,169 @@
+import { Link, useParams } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import unfurlLogo from "@/assets/unfurl-logo.png";
+import ItchIoLogo from "@/assets/itchio-logo.svg";
+import { DemoButton } from "@/features/demo";
+import { DialogViewer } from "@/features/dialog-viewer";
+import { DownloadButton } from "@/features/download";
+import { FileUpload } from "@/features/file-upload";
+import { useFaqModal } from "@/features/faq";
+import { MetadataConfig } from "@/features/metadata-config";
+import { NodeEditor } from "@/features/node-editor";
+import { getEditableFile } from "@/features/recent-files";
+import {
+  useDialogStore,
+  useJsonDataStore,
+  useNodeStore,
+} from "@/shared/stores";
+import { Button } from "@/shared/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card";
+
+interface PageProps {
+  isOnline: boolean;
+}
+
+const EmptyAppHero = ({ isOnline }: PageProps) => (
+  <>
+    <img
+      src={unfurlLogo}
+      alt="Unfurl logo"
+      aria-label="logo"
+      className="mx-auto h-32 p-6 transition-[filter] duration-300 [will-change:filter] hover:[filter:drop-shadow(0_0_2em_#646cffaa)]"
+    />
+    <h1 className="text-4xl font-bold">Unfurl{isOnline ? " Online" : ""}</h1>
+    <h2 className="box-content flex h-[27px] flex-row justify-center text-2xl">
+      <span className="overflow-hidden">
+        <span className="rotator-span">Twee</span>
+        <span className="rotator-span">Obsidian</span>
+        <span className="rotator-span">md</span>
+        <span className="rotator-span">JSON</span>
+        <span className="rotator-span">Twee</span>
+      </span>
+      <span className="ml-2">Convertor & Editor</span>
+    </h2>
+  </>
+);
+
+export const HomePage = ({ isOnline }: PageProps) => {
+  const setContent = useDialogStore((state) => state.setContent);
+  const resetJson = useJsonDataStore((state) => state.reset);
+  const setSelectedNode = useNodeStore((state) => state.setNode);
+  const faqModal = useFaqModal();
+
+  useEffect(() => {
+    resetJson();
+    setSelectedNode(null);
+  }, [resetJson, setSelectedNode]);
+
+  return (
+    <main className="flex flex-col items-center justify-center gap-4 p-6">
+      <EmptyAppHero isOnline={isOnline} />
+      <FileUpload />
+      <section className="flex flex-col items-center gap-4 pb-8">
+        <MetadataConfig />
+        <DemoButton />
+        {isOnline ? (
+          <Button asChild variant="secondary">
+            <a
+              href="https://hit-box38.itch.io/unfurl"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2"
+            >
+              <ItchIoLogo />
+              <span>Get the Desktop version</span>
+            </a>
+          </Button>
+        ) : null}
+        <Button variant="info" onClick={() => setContent(faqModal)}>
+          FAQ
+        </Button>
+      </section>
+    </main>
+  );
+};
+
+export const FilePage = () => {
+  const { fileId } = useParams({ strict: false }) as { fileId?: string };
+  const name = useJsonDataStore((state) => state.name);
+  const activeFileId = useJsonDataStore((state) => state.activeFileId);
+  const setJsonData = useJsonDataStore((state) => state.setJson);
+  const resetJson = useJsonDataStore((state) => state.reset);
+  const node = useNodeStore((state) => state.node);
+  const setSelectedNode = useNodeStore((state) => state.setNode);
+  const [isMissing, setIsMissing] = useState(false);
+
+  useEffect(() => {
+    if (!fileId) return;
+    const file = getEditableFile(fileId);
+    if (!file) {
+      setIsMissing(true);
+      resetJson();
+      setSelectedNode(null);
+      return;
+    }
+    setIsMissing(false);
+    setSelectedNode(null);
+    setJsonData(file.content, file.name, file.id);
+  }, [fileId, resetJson, setJsonData, setSelectedNode]);
+
+  if (isMissing) {
+    return (
+      <main className="flex min-h-screen items-center justify-center p-6">
+        <Card className="max-w-md text-left">
+          <CardHeader>
+            <CardTitle>File not found</CardTitle>
+            <CardDescription>
+              This editable file is no longer available in localStorage.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link to="/">Upload a file</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  if (!fileId || activeFileId !== fileId || name === "") {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <Loader2 className="animate-spin" aria-label="Loading editable file" />
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex flex-col items-center justify-center gap-4 p-6">
+      <div className="flex w-full max-w-6xl items-center justify-between gap-4">
+        <div className="text-left">
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">
+            Editing
+          </p>
+          <h1 className="text-3xl font-bold">{name}</h1>
+        </div>
+        <Button asChild variant="secondary">
+          <Link to="/">Upload another file</Link>
+        </Button>
+      </div>
+      <section className="mx-auto flex w-full max-w-6xl flex-row items-start justify-evenly py-4">
+        <DialogViewer />
+        {node ? <NodeEditor /> : null}
+      </section>
+      <section className="flex flex-col items-center gap-4 pb-8">
+        <DownloadButton />
+        <DemoButton />
+      </section>
+    </main>
+  );
+};

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,39 @@
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
+import App from "@/app/app";
+import { FilePage, HomePage } from "@/app/pages";
+
+const isOnlineHost = () =>
+  typeof location !== "undefined" &&
+  location.hostname.includes(".vercel.app") &&
+  location.hostname.includes("unfurl");
+
+const rootRoute = createRootRoute({
+  component: App,
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: () => <HomePage isOnline={isOnlineHost()} />,
+});
+
+const fileRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/files/$fileId",
+  component: FilePage,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, fileRoute]);
+
+export const router = createRouter({ routeTree });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/src/features/demo/demo-button.test.tsx
+++ b/src/features/demo/demo-button.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getEditableFile } from "@/features/recent-files";
+import { fromTwee } from "@/shared/lib/convertors";
+import { useJsonDataStore } from "@/shared/stores";
+import type { StoryData } from "@/shared/types";
+
+import { DemoButton } from "@/features/demo/demo-button";
+
+const { navigate } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@/shared/lib/convertors", () => ({
+  fromTwee: vi.fn(),
+}));
+
+const demoStory: StoryData = {
+  title: "Demo Story",
+  start: "Start",
+  nodes: [
+    {
+      name: "Start",
+      content: ["Hello"],
+      choices: [],
+      metadata: {},
+    },
+  ],
+};
+
+const revealDemoButton = () => {
+  for (const code of [
+    "ArrowUp",
+    "ArrowUp",
+    "ArrowDown",
+    "ArrowDown",
+    "ArrowLeft",
+    "ArrowRight",
+    "ArrowLeft",
+    "ArrowRight",
+    "KeyB",
+    "KeyA",
+  ]) {
+    fireEvent.keyDown(window, { code });
+  }
+};
+
+describe("DemoButton", () => {
+  beforeEach(() => {
+    navigate.mockReset();
+    vi.mocked(fromTwee).mockResolvedValue(demoStory);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(":: Start\nHello")),
+    );
+    useJsonDataStore.getState().reset();
+  });
+
+  it("loads the demo as an editable file route", async () => {
+    render(<DemoButton />);
+    revealDemoButton();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /load demo file/i }),
+    );
+
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    const activeFileId = useJsonDataStore.getState().activeFileId;
+    expect(activeFileId).toEqual(expect.any(String));
+    expect(getEditableFile(activeFileId ?? "")?.content).toEqual(demoStory);
+    expect(navigate).toHaveBeenCalledWith({
+      to: "/files/$fileId",
+      params: { fileId: activeFileId },
+    });
+  });
+});

--- a/src/features/demo/demo-button.tsx
+++ b/src/features/demo/demo-button.tsx
@@ -1,8 +1,8 @@
 import { Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { useOpenEditableFile } from "@/features/recent-files";
 import { fromTwee } from "@/shared/lib/convertors";
-import { useJsonDataStore } from "@/shared/stores";
 import { Button } from "@/shared/ui/button";
 
 const KONAMI_SEQUENCE = [
@@ -23,7 +23,7 @@ const RESET_DELAY_MS = 2000;
 export const DemoButton = () => {
   const [isDemoFileButtonVisible, setIsDemoFileButtonVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const setJsonData = useJsonDataStore((state) => state.setJson);
+  const openEditableFile = useOpenEditableFile();
 
   const inputSequence = useRef<string[]>([]);
   const resetTimer = useRef<number | null>(null);
@@ -72,7 +72,7 @@ export const DemoButton = () => {
       const blob = await response.blob();
       const file = new File([blob], "Lorcan02.1.twee");
       const data = await fromTwee(file);
-      setJsonData(data, "Lorcan02.1");
+      openEditableFile(data, "Lorcan02.1", "twee");
     } finally {
       setIsLoading(false);
     }

--- a/src/features/dialog-viewer/dialog-graph.ts
+++ b/src/features/dialog-viewer/dialog-graph.ts
@@ -1,0 +1,76 @@
+import type { Edge, Node } from "@xyflow/react";
+import dagre from "dagre";
+
+import type { StoryData, StoryNode } from "@/shared/types";
+
+export interface DialogNodeData extends Record<string, unknown> {
+  label: string;
+  metadata: StoryNode;
+}
+
+const NODE_WIDTH = 150;
+const NODE_HEIGHT = 50;
+
+const getNodeDimensions = (node: Node<DialogNodeData>) => ({
+  width: node.data.metadata.size?.width ?? NODE_WIDTH,
+  height: node.data.metadata.size?.height ?? NODE_HEIGHT,
+});
+
+const layoutDagre = (
+  nodes: Node<DialogNodeData>[],
+  edges: Edge[],
+): Node<DialogNodeData>[] => {
+  const graph = new dagre.graphlib.Graph();
+  graph.setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({});
+
+  nodes.forEach((node) => {
+    graph.setNode(node.id, getNodeDimensions(node));
+  });
+
+  edges.forEach((edge) => {
+    graph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(graph);
+
+  return nodes.map((node) => {
+    const positioned = graph.node(node.id);
+    const { width, height } = getNodeDimensions(node);
+    return {
+      ...node,
+      position: {
+        x: positioned.x - width / 2,
+        y: positioned.y - height / 2,
+      },
+    };
+  });
+};
+
+export const buildDialogGraph = (
+  json: StoryData,
+): { nodes: Node<DialogNodeData>[]; edges: Edge[] } => {
+  const nodes: Node<DialogNodeData>[] = json.nodes.map((node) => ({
+    id: node.name,
+    data: { label: node.name, metadata: node },
+    position: node.position ?? { x: 0, y: 0 },
+    ...(node.size
+      ? { style: { width: node.size.width, height: node.size.height } }
+      : {}),
+  }));
+
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const edges: Edge[] = json.nodes.flatMap((node) =>
+    node.choices.flatMap((choice, choiceIndex) => {
+      if (!nodeIds.has(choice.destination)) return [];
+      return {
+        id: `e${node.name}-${choice.destination}-${choiceIndex}`,
+        source: node.name,
+        target: choice.destination,
+      } satisfies Edge;
+    }),
+  );
+
+  const hasStoredPositions = nodes.every((node) => node.data.metadata.position);
+  return { nodes: hasStoredPositions ? nodes : layoutDagre(nodes, edges), edges };
+};

--- a/src/features/dialog-viewer/dialog-graph.ts
+++ b/src/features/dialog-viewer/dialog-graph.ts
@@ -54,9 +54,6 @@ export const buildDialogGraph = (
     id: node.name,
     data: { label: node.name, metadata: node },
     position: node.position ?? { x: 0, y: 0 },
-    ...(node.size
-      ? { style: { width: node.size.width, height: node.size.height } }
-      : {}),
   }));
 
   const nodeIds = new Set(nodes.map((node) => node.id));

--- a/src/features/dialog-viewer/dialog-viewer.component.test.tsx
+++ b/src/features/dialog-viewer/dialog-viewer.component.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useJsonDataStore } from "@/shared/stores";
+
+import { DialogViewer } from "@/features/dialog-viewer/dialog-viewer";
+
+const { reactFlow } = vi.hoisted(() => ({
+  reactFlow: vi.fn(() => <div data-testid="react-flow" />),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  ConnectionLineType: { Step: "step" },
+  ReactFlow: reactFlow,
+  useEdgesState: <T,>(initial: T[]) => [initial, vi.fn(), vi.fn()],
+  useNodesState: <T,>(initial: T[]) => [initial, vi.fn(), vi.fn()],
+}));
+
+const story = {
+  title: "Demo",
+  start: "Intro",
+  nodes: [
+    {
+      name: "Intro",
+      position: { x: 0, y: 0 },
+      metadata: {},
+      content: [],
+      choices: [],
+    },
+  ],
+};
+
+describe("DialogViewer", () => {
+  afterEach(() => {
+    reactFlow.mockClear();
+    Reflect.deleteProperty(window, "ipcRenderer");
+    useJsonDataStore.getState().reset();
+  });
+
+  it("renders React Flow in dark mode so node labels remain visible", () => {
+    useJsonDataStore.getState().setJson(story, "demo", "demo-id");
+
+    render(<DialogViewer />);
+
+    expect(reactFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ colorMode: "dark" }),
+      undefined,
+    );
+  });
+
+  it("uses full web width outside Electron", () => {
+    useJsonDataStore.getState().setJson(story, "demo", "demo-id");
+
+    render(<DialogViewer />);
+
+    expect(screen.getByLabelText(/dialog flow chart/i)).toHaveStyle({
+      width: "100%",
+    });
+  });
+});

--- a/src/features/dialog-viewer/dialog-viewer.test.ts
+++ b/src/features/dialog-viewer/dialog-viewer.test.ts
@@ -12,6 +12,7 @@ describe("buildDialogGraph", () => {
         {
           name: "Intro",
           position: { x: 25, y: 50 },
+          size: { width: 100, height: 100 },
           metadata: {},
           content: [],
           choices: [{ text: "Next", destination: "Outro" }],
@@ -19,6 +20,7 @@ describe("buildDialogGraph", () => {
         {
           name: "Outro",
           position: { x: 200, y: 50 },
+          size: { width: 100, height: 100 },
           metadata: {},
           content: [],
           choices: [],
@@ -29,6 +31,10 @@ describe("buildDialogGraph", () => {
     expect(graph.nodes.map((node) => [node.id, node.position])).toEqual([
       ["Intro", { x: 25, y: 50 }],
       ["Outro", { x: 200, y: 50 }],
+    ]);
+    expect(graph.nodes.map((node) => node.style)).toEqual([
+      undefined,
+      undefined,
     ]);
     expect(graph.edges).toEqual([
       expect.objectContaining({ source: "Intro", target: "Outro" }),

--- a/src/features/dialog-viewer/dialog-viewer.test.ts
+++ b/src/features/dialog-viewer/dialog-viewer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDialogGraph } from "@/features/dialog-viewer/dialog-graph";
+import type { StoryData } from "@/shared/types";
+
+describe("buildDialogGraph", () => {
+  it("uses stored Twee positions and stable node-name ids", () => {
+    const graph = buildDialogGraph({
+      title: "Demo",
+      start: "Intro",
+      nodes: [
+        {
+          name: "Intro",
+          position: { x: 25, y: 50 },
+          metadata: {},
+          content: [],
+          choices: [{ text: "Next", destination: "Outro" }],
+        },
+        {
+          name: "Outro",
+          position: { x: 200, y: 50 },
+          metadata: {},
+          content: [],
+          choices: [],
+        },
+      ],
+    } satisfies StoryData);
+
+    expect(graph.nodes.map((node) => [node.id, node.position])).toEqual([
+      ["Intro", { x: 25, y: 50 }],
+      ["Outro", { x: 200, y: 50 }],
+    ]);
+    expect(graph.edges).toEqual([
+      expect.objectContaining({ source: "Intro", target: "Outro" }),
+    ]);
+  });
+
+  it("does not create edges to missing destination nodes", () => {
+    const graph = buildDialogGraph({
+      title: "Demo",
+      start: "Intro",
+      nodes: [
+        {
+          name: "Intro",
+          metadata: {},
+          content: [],
+          choices: [{ text: "Broken", destination: "Missing" }],
+        },
+      ],
+    } satisfies StoryData);
+
+    expect(graph.edges).toEqual([]);
+  });
+});

--- a/src/features/dialog-viewer/dialog-viewer.tsx
+++ b/src/features/dialog-viewer/dialog-viewer.tsx
@@ -7,7 +7,7 @@ import {
   type Node,
 } from "@xyflow/react";
 import dagre from "dagre";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { useJsonDataStore, useNodeStore } from "@/shared/stores";
 import type { StoryData, StoryNode } from "@/shared/types";
@@ -100,6 +100,10 @@ export const DialogViewer = () => {
   }, [content, setNodes, setEdges]);
 
   const width = isOnlineHost() ? "100%" : "500px";
+
+  useEffect(() => {
+    onLayout();
+  }, [onLayout]);
 
   return (
     <div

--- a/src/features/dialog-viewer/dialog-viewer.tsx
+++ b/src/features/dialog-viewer/dialog-viewer.tsx
@@ -6,74 +6,13 @@ import {
   type Edge,
   type Node,
 } from "@xyflow/react";
-import dagre from "dagre";
 import { useCallback, useEffect, useMemo } from "react";
 
 import { useJsonDataStore, useNodeStore } from "@/shared/stores";
-import type { StoryData, StoryNode } from "@/shared/types";
-
-interface DialogNodeData extends Record<string, unknown> {
-  label: string;
-  metadata: StoryNode;
-}
-
-const NODE_WIDTH = 150;
-const NODE_HEIGHT = 50;
-
-const layoutDagre = (
-  nodes: Node<DialogNodeData>[],
-  edges: Edge[],
-): Node<DialogNodeData>[] => {
-  const graph = new dagre.graphlib.Graph();
-  graph.setDefaultEdgeLabel(() => ({}));
-  graph.setGraph({});
-
-  nodes.forEach((node) => {
-    graph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
-  });
-
-  edges.forEach((edge) => {
-    graph.setEdge(edge.source, edge.target);
-  });
-
-  dagre.layout(graph);
-
-  return nodes.map((node) => {
-    const positioned = graph.node(node.id);
-    return {
-      ...node,
-      position: {
-        x: positioned.x - NODE_WIDTH / 2,
-        y: positioned.y - NODE_HEIGHT / 2,
-      },
-    };
-  });
-};
-
-const transformJsonToNodesAndEdges = (
-  json: StoryData,
-): { nodes: Node<DialogNodeData>[]; edges: Edge[] } => {
-  const nodes: Node<DialogNodeData>[] = json.nodes.map((node, index) => ({
-    id: index.toString(),
-    data: { label: node.name, metadata: node },
-    position: { x: 0, y: 0 },
-  }));
-
-  const edges: Edge[] = json.nodes.flatMap((node, index) =>
-    node.choices.map((choice) => {
-      const targetIndex = json.nodes.findIndex(
-        (n) => n.name === choice.destination,
-      );
-      return {
-        id: `e${index}-${targetIndex}`,
-        source: index.toString(),
-        target: targetIndex.toString(),
-      } satisfies Edge;
-    }),
-  );
-
-  return { nodes: layoutDagre(nodes, edges), edges };
-};
+import {
+  buildDialogGraph,
+  type DialogNodeData,
+} from "@/features/dialog-viewer/dialog-graph";
 
 const isOnlineHost = () =>
   location.hostname.includes(".vercel.app") &&
@@ -84,7 +23,7 @@ export const DialogViewer = () => {
   const setSelectedNode = useNodeStore((state) => state.setNode);
 
   const initial = useMemo(
-    () => transformJsonToNodesAndEdges(content),
+    () => buildDialogGraph(content),
     [content],
   );
 
@@ -94,7 +33,7 @@ export const DialogViewer = () => {
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(initial.edges);
 
   const onLayout = useCallback(() => {
-    const updated = transformJsonToNodesAndEdges(content);
+    const updated = buildDialogGraph(content);
     setNodes([...updated.nodes]);
     setEdges([...updated.edges]);
   }, [content, setNodes, setEdges]);

--- a/src/features/dialog-viewer/dialog-viewer.tsx
+++ b/src/features/dialog-viewer/dialog-viewer.tsx
@@ -14,9 +14,8 @@ import {
   type DialogNodeData,
 } from "@/features/dialog-viewer/dialog-graph";
 
-const isOnlineHost = () =>
-  location.hostname.includes(".vercel.app") &&
-  location.hostname.includes("unfurl");
+const isElectronRenderer = () =>
+  typeof window !== "undefined" && Boolean(window.ipcRenderer);
 
 export const DialogViewer = () => {
   const content = useJsonDataStore((state) => state.content);
@@ -38,7 +37,7 @@ export const DialogViewer = () => {
     setEdges([...updated.edges]);
   }, [content, setNodes, setEdges]);
 
-  const width = isOnlineHost() ? "100%" : "500px";
+  const width = isElectronRenderer() ? "500px" : "100%";
 
   useEffect(() => {
     onLayout();
@@ -46,11 +45,13 @@ export const DialogViewer = () => {
 
   return (
     <div
+      aria-label="Dialog flow chart"
       className="mr-6 h-[750px] rounded-xl bg-[#121212] bg-[image:linear-gradient(rgba(255,255,255,0.05),rgba(255,255,255,0.05))] shadow-md transition-shadow"
       style={{ width }}
     >
       <ReactFlow
         fitView
+        colorMode="dark"
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}

--- a/src/features/file-upload/file-upload.test.tsx
+++ b/src/features/file-upload/file-upload.test.tsx
@@ -1,13 +1,22 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useJsonDataStore } from "@/shared/stores";
 
 import { FileUpload } from "@/features/file-upload/file-upload";
 
+const { navigate } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
 describe("FileUpload", () => {
   beforeEach(() => {
+    navigate.mockReset();
     useJsonDataStore.getState().reset();
   });
 

--- a/src/features/file-upload/file-upload.test.tsx
+++ b/src/features/file-upload/file-upload.test.tsx
@@ -54,6 +54,25 @@ describe("FileUpload", () => {
     expect(fileInput).toHaveAttribute("multiple");
   });
 
+  it("keeps md upload disabled until a title is provided", async () => {
+    render(<FileUpload />);
+    const trigger = screen.getByLabelText(/file type/i);
+    await userEvent.click(trigger);
+    await userEvent.click(
+      screen.getByRole("option", { name: /Obsidian/i }),
+    );
+
+    const fileInput = screen.getByLabelText(/select \.md files/i, {
+      selector: "input",
+    }) as HTMLInputElement;
+    await userEvent.upload(
+      fileInput,
+      new File(["# Intro"], "intro.md", { type: "text/markdown" }),
+    );
+
+    expect(screen.getByRole("button", { name: /^upload$/i })).toBeDisabled();
+  });
+
   it("upload button is disabled until a file is selected", () => {
     render(<FileUpload />);
     const upload = screen.getByRole("button", { name: /^upload$/i });

--- a/src/features/file-upload/file-upload.tsx
+++ b/src/features/file-upload/file-upload.tsx
@@ -4,12 +4,10 @@ import {
   Trash2,
   Upload,
 } from "lucide-react";
-import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useState, type ChangeEvent } from "react";
 
 import { useStorage } from "@/shared/hooks";
 import { fromMd, fromTwee } from "@/shared/lib/convertors";
-import { useJsonDataStore } from "@/shared/stores";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
@@ -26,7 +24,7 @@ import {
   type StoryData,
   type SupportedFileType,
 } from "@/shared/types";
-import { saveEditableFile } from "@/features/recent-files";
+import { useOpenEditableFile } from "@/features/recent-files";
 
 const FILE_TYPE_LABEL: Record<SupportedFileType, string> = {
   twee: "Twee",
@@ -45,8 +43,7 @@ export const FileUpload = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [fileType, setFileType] = useState<SupportedFileType>("twee");
   const [caughtError, setCaughtError] = useState<string | null>(null);
-  const setJsonData = useJsonDataStore((state) => state.setJson);
-  const navigate = useNavigate();
+  const openEditableFile = useOpenEditableFile();
 
   const [{ config }] = useStorage<MetadataConfigTemplate>({
     key: "metadataConfig",
@@ -84,10 +81,10 @@ export const FileUpload = () => {
     try {
       if (fileType === "twee") {
         const data = await fromTwee(files[0]);
-        openEditableFile(data, files[0].name.split(".")[0]);
+        openEditableFile(data, files[0].name.split(".")[0], fileType);
       } else if (fileType === "md") {
         const data = await fromMd(files, title);
-        openEditableFile(data, title);
+        openEditableFile(data, title, fileType);
       } else if (fileType === "json") {
         const text = await files[0].text();
         const json = JSON.parse(text) as StoryData;
@@ -107,7 +104,7 @@ export const FileUpload = () => {
             metadata: { ...node.metadata, ...extras },
           };
         });
-        openEditableFile(json, files[0].name.split(".")[0]);
+        openEditableFile(json, files[0].name.split(".")[0], fileType);
       }
     } catch (error) {
       setCaughtError(error instanceof Error ? error.message : String(error));
@@ -119,21 +116,13 @@ export const FileUpload = () => {
   const uploadDisabled =
     isLoading ||
     files.length === 0 ||
-    files.some((file) => fileExtension(file) !== fileType);
+    files.some((file) => fileExtension(file) !== fileType) ||
+    (fileType === "md" && title.trim() === "");
 
   const inputLabelText =
     fileType === "md"
       ? "Select .md files"
       : `Select a .${fileType} file`;
-
-  const openEditableFile = (content: StoryData, name: string) => {
-    const record = saveEditableFile({ name, fileType, content });
-    setJsonData(record.content, record.name, record.id);
-    void navigate({
-      to: "/files/$fileId",
-      params: { fileId: record.id },
-    });
-  };
 
   return (
     <div className="flex flex-col items-center justify-center gap-2">

--- a/src/features/file-upload/file-upload.tsx
+++ b/src/features/file-upload/file-upload.tsx
@@ -4,6 +4,7 @@ import {
   Trash2,
   Upload,
 } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useState, type ChangeEvent } from "react";
 
 import { useStorage } from "@/shared/hooks";
@@ -25,6 +26,7 @@ import {
   type StoryData,
   type SupportedFileType,
 } from "@/shared/types";
+import { saveEditableFile } from "@/features/recent-files";
 
 const FILE_TYPE_LABEL: Record<SupportedFileType, string> = {
   twee: "Twee",
@@ -43,8 +45,8 @@ export const FileUpload = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [fileType, setFileType] = useState<SupportedFileType>("twee");
   const [caughtError, setCaughtError] = useState<string | null>(null);
-  const currentName = useJsonDataStore((state) => state.name);
   const setJsonData = useJsonDataStore((state) => state.setJson);
+  const navigate = useNavigate();
 
   const [{ config }] = useStorage<MetadataConfigTemplate>({
     key: "metadataConfig",
@@ -82,16 +84,10 @@ export const FileUpload = () => {
     try {
       if (fileType === "twee") {
         const data = await fromTwee(files[0]);
-        if (currentName !== "") {
-          setJsonData({ nodes: [], start: null, title: null }, "");
-        }
-        setJsonData(data, files[0].name.split(".")[0]);
+        openEditableFile(data, files[0].name.split(".")[0]);
       } else if (fileType === "md") {
         const data = await fromMd(files, title);
-        if (currentName !== "") {
-          setJsonData({ nodes: [], start: null, title: null }, "");
-        }
-        setJsonData(data, title);
+        openEditableFile(data, title);
       } else if (fileType === "json") {
         const text = await files[0].text();
         const json = JSON.parse(text) as StoryData;
@@ -111,7 +107,7 @@ export const FileUpload = () => {
             metadata: { ...node.metadata, ...extras },
           };
         });
-        setJsonData(json, files[0].name.split(".")[0]);
+        openEditableFile(json, files[0].name.split(".")[0]);
       }
     } catch (error) {
       setCaughtError(error instanceof Error ? error.message : String(error));
@@ -129,6 +125,15 @@ export const FileUpload = () => {
     fileType === "md"
       ? "Select .md files"
       : `Select a .${fileType} file`;
+
+  const openEditableFile = (content: StoryData, name: string) => {
+    const record = saveEditableFile({ name, fileType, content });
+    setJsonData(record.content, record.name, record.id);
+    void navigate({
+      to: "/files/$fileId",
+      params: { fileId: record.id },
+    });
+  };
 
   return (
     <div className="flex flex-col items-center justify-center gap-2">

--- a/src/features/recent-files/index.ts
+++ b/src/features/recent-files/index.ts
@@ -1,0 +1,11 @@
+export {
+  EDITABLE_FILES_STORAGE_KEY,
+  getEditableFile,
+  listEditableFiles,
+  saveEditableFile,
+  searchEditableFiles,
+  updateEditableFileContent,
+  type EditableFileDraft,
+  type EditableFileRecord,
+} from "@/features/recent-files/recent-files-storage";
+export { RecentFilesSidebar } from "@/features/recent-files/recent-files-sidebar";

--- a/src/features/recent-files/index.ts
+++ b/src/features/recent-files/index.ts
@@ -9,3 +9,4 @@ export {
   type EditableFileRecord,
 } from "@/features/recent-files/recent-files-storage";
 export { RecentFilesSidebar } from "@/features/recent-files/recent-files-sidebar";
+export { useOpenEditableFile } from "@/features/recent-files/use-open-editable-file";

--- a/src/features/recent-files/recent-files-sidebar.tsx
+++ b/src/features/recent-files/recent-files-sidebar.tsx
@@ -1,0 +1,122 @@
+import { Link } from "@tanstack/react-router";
+import { FileText, Search } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  EDITABLE_FILES_STORAGE_KEY,
+  searchEditableFiles,
+  type EditableFileRecord,
+} from "@/features/recent-files";
+import { STORAGE_EVENT } from "@/shared/hooks";
+import { Input } from "@/shared/ui/input";
+
+const formatUpdatedAt = (updatedAt: number) =>
+  new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(updatedAt));
+
+export const RecentFilesSidebar = () => {
+  const [query, setQuery] = useState("");
+  const [files, setFiles] = useState<EditableFileRecord[]>(() =>
+    searchEditableFiles(""),
+  );
+
+  const refreshFiles = useCallback(() => {
+    setFiles(searchEditableFiles(query));
+  }, [query]);
+
+  useEffect(() => {
+    refreshFiles();
+  }, [refreshFiles]);
+
+  useEffect(() => {
+    const onStorageChange = (
+      event: CustomEvent<{ key: string; newValue: EditableFileRecord[] }>,
+    ) => {
+      if (event.detail.key === EDITABLE_FILES_STORAGE_KEY) {
+        setFiles(
+          query.trim()
+            ? searchEditableFiles(query)
+            : [...event.detail.newValue].sort(
+                (a, b) => b.updatedAt - a.updatedAt,
+              ),
+        );
+      }
+    };
+    const onNativeStorage = (event: StorageEvent) => {
+      if (event.key === EDITABLE_FILES_STORAGE_KEY) {
+        refreshFiles();
+      }
+    };
+
+    window.addEventListener(STORAGE_EVENT, onStorageChange as EventListener);
+    window.addEventListener("storage", onNativeStorage);
+    return () => {
+      window.removeEventListener(STORAGE_EVENT, onStorageChange as EventListener);
+      window.removeEventListener("storage", onNativeStorage);
+    };
+  }, [query, refreshFiles]);
+
+  return (
+    <aside className="flex min-h-screen w-72 shrink-0 flex-col gap-4 border-r bg-card/70 p-4 text-left">
+      <div>
+        <h2 className="text-lg font-semibold">Editable files</h2>
+        <p className="text-sm text-muted-foreground">
+          Browse files saved on this device.
+        </p>
+      </div>
+      <label className="relative block">
+        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          aria-label="Search editable files"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search files"
+          className="pl-9"
+        />
+      </label>
+      <nav aria-label="Editable files" className="flex flex-1 flex-col gap-2">
+        {files.length > 0 ? (
+          files.map((file) => (
+            <RecentFileLink key={file.id} file={file} />
+          ))
+        ) : (
+          <p className="rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
+            {query.trim()
+              ? "No editable files match your search."
+              : "Uploaded files will appear here."}
+          </p>
+        )}
+      </nav>
+    </aside>
+  );
+};
+
+const RecentFileLink = ({ file }: { file: EditableFileRecord }) => (
+  <Link
+    to="/files/$fileId"
+    params={{ fileId: file.id }}
+    className="rounded-lg border bg-background/60 p-3 text-left transition-colors hover:bg-accent"
+    activeProps={{
+      className: "border-primary bg-primary/20",
+    }}
+  >
+    <span className="flex items-start gap-2">
+      <FileText className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0">
+        <span className="block truncate font-medium">{file.name}</span>
+        {file.content.title ? (
+          <span className="block truncate text-xs text-muted-foreground">
+            {file.content.title}
+          </span>
+        ) : null}
+        <span className="mt-1 block text-xs uppercase tracking-wide text-muted-foreground">
+          {file.fileType} - {formatUpdatedAt(file.updatedAt)}
+        </span>
+      </span>
+    </span>
+  </Link>
+);

--- a/src/features/recent-files/recent-files-sidebar.tsx
+++ b/src/features/recent-files/recent-files-sidebar.tsx
@@ -96,21 +96,23 @@ export const RecentFilesSidebar = () => {
         <SidebarGroup>
           <SidebarGroupLabel>Past files</SidebarGroupLabel>
           <SidebarGroupContent>
-            <SidebarMenu aria-label="Editable files">
-              {files.length > 0 ? (
-                files.map((file) => (
-                  <RecentFileLink key={file.id} file={file} />
-                ))
-              ) : (
-                <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
-                  <p className="rounded-lg border border-dashed p-3 text-sm text-sidebar-foreground/70">
-                    {query.trim()
-                      ? "No editable files match your search."
-                      : "Uploaded files will appear here."}
-                  </p>
-                </SidebarMenuItem>
-              )}
-            </SidebarMenu>
+            <nav aria-label="Editable files">
+              <SidebarMenu>
+                {files.length > 0 ? (
+                  files.map((file) => (
+                    <RecentFileLink key={file.id} file={file} />
+                  ))
+                ) : (
+                  <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
+                    <p className="rounded-lg border border-dashed p-3 text-sm text-sidebar-foreground/70">
+                      {query.trim()
+                        ? "No editable files match your search."
+                        : "Uploaded files will appear here."}
+                    </p>
+                  </SidebarMenuItem>
+                )}
+              </SidebarMenu>
+            </nav>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>

--- a/src/features/recent-files/recent-files-sidebar.tsx
+++ b/src/features/recent-files/recent-files-sidebar.tsx
@@ -8,7 +8,19 @@ import {
   type EditableFileRecord,
 } from "@/features/recent-files";
 import { STORAGE_EVENT } from "@/shared/hooks";
-import { Input } from "@/shared/ui/input";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from "@/shared/ui/sidebar";
 
 const formatUpdatedAt = (updatedAt: number) =>
   new Intl.DateTimeFormat(undefined, {
@@ -61,62 +73,75 @@ export const RecentFilesSidebar = () => {
   }, [query, refreshFiles]);
 
   return (
-    <aside className="flex min-h-screen w-72 shrink-0 flex-col gap-4 border-r bg-card/70 p-4 text-left">
-      <div>
-        <h2 className="text-lg font-semibold">Editable files</h2>
-        <p className="text-sm text-muted-foreground">
-          Browse files saved on this device.
-        </p>
-      </div>
-      <label className="relative block">
-        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          aria-label="Search editable files"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search files"
-          className="pl-9"
-        />
-      </label>
-      <nav aria-label="Editable files" className="flex flex-1 flex-col gap-2">
-        {files.length > 0 ? (
-          files.map((file) => (
-            <RecentFileLink key={file.id} file={file} />
-          ))
-        ) : (
-          <p className="rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
-            {query.trim()
-              ? "No editable files match your search."
-              : "Uploaded files will appear here."}
+    <Sidebar collapsible="icon" aria-label="Editable files sidebar">
+      <SidebarHeader>
+        <div className="px-2 py-1 group-data-[collapsible=icon]:hidden">
+          <h2 className="text-lg font-semibold">Editable files</h2>
+          <p className="text-sm text-sidebar-foreground/70">
+            Browse files saved on this device.
           </p>
-        )}
-      </nav>
-    </aside>
+        </div>
+        <label className="relative block px-2 group-data-[collapsible=icon]:hidden">
+          <Search className="pointer-events-none absolute left-5 top-1/2 size-4 -translate-y-1/2 text-sidebar-foreground/70" />
+          <SidebarInput
+            aria-label="Search editable files"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search files"
+            className="pl-9"
+          />
+        </label>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Past files</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu aria-label="Editable files">
+              {files.length > 0 ? (
+                files.map((file) => (
+                  <RecentFileLink key={file.id} file={file} />
+                ))
+              ) : (
+                <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
+                  <p className="rounded-lg border border-dashed p-3 text-sm text-sidebar-foreground/70">
+                    {query.trim()
+                      ? "No editable files match your search."
+                      : "Uploaded files will appear here."}
+                  </p>
+                </SidebarMenuItem>
+              )}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarRail />
+    </Sidebar>
   );
 };
 
 const RecentFileLink = ({ file }: { file: EditableFileRecord }) => (
-  <Link
-    to="/files/$fileId"
-    params={{ fileId: file.id }}
-    className="rounded-lg border bg-background/60 p-3 text-left transition-colors hover:bg-accent"
-    activeProps={{
-      className: "border-primary bg-primary/20",
-    }}
-  >
-    <span className="flex items-start gap-2">
-      <FileText className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-      <span className="min-w-0">
-        <span className="block truncate font-medium">{file.name}</span>
-        {file.content.title ? (
-          <span className="block truncate text-xs text-muted-foreground">
-            {file.content.title}
+  <SidebarMenuItem>
+    <SidebarMenuButton asChild tooltip={file.name} className="h-auto min-h-10">
+      <Link
+        to="/files/$fileId"
+        params={{ fileId: file.id }}
+        activeProps={{
+          className: "bg-sidebar-accent text-sidebar-accent-foreground",
+        }}
+      >
+        <FileText className="size-4" />
+        <span className="min-w-0">
+          <span className="block truncate font-medium">{file.name}</span>
+          {file.content.title ? (
+            <span className="block truncate text-xs text-sidebar-foreground/70">
+              {file.content.title}
+            </span>
+          ) : null}
+          <span className="mt-0.5 block truncate text-xs uppercase tracking-wide text-sidebar-foreground/70">
+            {file.fileType} - {formatUpdatedAt(file.updatedAt)}
           </span>
-        ) : null}
-        <span className="mt-1 block text-xs uppercase tracking-wide text-muted-foreground">
-          {file.fileType} - {formatUpdatedAt(file.updatedAt)}
         </span>
-      </span>
-    </span>
-  </Link>
+      </Link>
+    </SidebarMenuButton>
+  </SidebarMenuItem>
 );

--- a/src/features/recent-files/recent-files-storage.test.ts
+++ b/src/features/recent-files/recent-files-storage.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getEditableFile,
+  listEditableFiles,
+  saveEditableFile,
+  searchEditableFiles,
+  updateEditableFileContent,
+} from "@/features/recent-files";
+import type { StoryData } from "@/shared/types";
+
+const firstStory: StoryData = {
+  title: "First Story",
+  start: "Start",
+  nodes: [
+    {
+      name: "Start",
+      content: ["Hello"],
+      choices: [],
+      metadata: {},
+    },
+  ],
+};
+
+const secondStory: StoryData = {
+  title: "Second Story",
+  start: "Intro",
+  nodes: [
+    {
+      name: "Intro",
+      content: ["Hi"],
+      choices: [],
+      metadata: {},
+    },
+  ],
+};
+
+describe("recent editable file storage", () => {
+  it("stores editable files newest first", () => {
+    const storage = localStorage;
+
+    const first = saveEditableFile(
+      { name: "alpha", fileType: "twee", content: firstStory },
+      { storage, now: () => 100, createId: () => "first" },
+    );
+    const second = saveEditableFile(
+      { name: "beta", fileType: "json", content: secondStory },
+      { storage, now: () => 200, createId: () => "second" },
+    );
+
+    expect(first.id).toBe("first");
+    expect(listEditableFiles({ storage }).map((file) => file.id)).toEqual([
+      second.id,
+      first.id,
+    ]);
+  });
+
+  it("updates an existing editable file instead of duplicating it", () => {
+    const storage = localStorage;
+
+    saveEditableFile(
+      { name: "draft", fileType: "twee", content: firstStory },
+      { storage, now: () => 100, createId: () => "draft-id" },
+    );
+    saveEditableFile(
+      {
+        id: "draft-id",
+        name: "renamed draft",
+        fileType: "json",
+        content: secondStory,
+      },
+      { storage, now: () => 300, createId: () => "unused" },
+    );
+
+    const files = listEditableFiles({ storage });
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      id: "draft-id",
+      name: "renamed draft",
+      fileType: "json",
+      updatedAt: 300,
+      content: secondStory,
+    });
+  });
+
+  it("searches editable files by name and title case-insensitively", () => {
+    const storage = localStorage;
+
+    saveEditableFile(
+      { name: "lorcan", fileType: "twee", content: firstStory },
+      { storage, now: () => 100, createId: () => "first" },
+    );
+    saveEditableFile(
+      { name: "archive", fileType: "json", content: secondStory },
+      { storage, now: () => 200, createId: () => "second" },
+    );
+
+    expect(searchEditableFiles("LOR", { storage })).toHaveLength(1);
+    expect(searchEditableFiles("second story", { storage })).toHaveLength(1);
+    expect(searchEditableFiles("missing", { storage })).toHaveLength(0);
+  });
+
+  it("persists edited content for an existing editable file", () => {
+    const storage = localStorage;
+
+    saveEditableFile(
+      { name: "draft", fileType: "twee", content: firstStory },
+      { storage, now: () => 100, createId: () => "draft-id" },
+    );
+
+    const editedStory: StoryData = {
+      ...firstStory,
+      nodes: [
+        {
+          ...firstStory.nodes[0],
+          content: ["Edited"],
+        },
+      ],
+    };
+
+    updateEditableFileContent("draft-id", editedStory, {
+      storage,
+      now: () => 500,
+    });
+
+    expect(getEditableFile("draft-id", { storage })?.content).toEqual(
+      editedStory,
+    );
+    expect(getEditableFile("draft-id", { storage })?.updatedAt).toBe(500);
+  });
+});

--- a/src/features/recent-files/recent-files-storage.ts
+++ b/src/features/recent-files/recent-files-storage.ts
@@ -1,0 +1,10 @@
+export {
+  EDITABLE_FILES_STORAGE_KEY,
+  getEditableFile,
+  listEditableFiles,
+  saveEditableFile,
+  searchEditableFiles,
+  updateEditableFileContent,
+  type EditableFileDraft,
+  type EditableFileRecord,
+} from "@/shared/lib/editable-files-storage";

--- a/src/features/recent-files/use-open-editable-file.ts
+++ b/src/features/recent-files/use-open-editable-file.ts
@@ -1,0 +1,29 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+
+import { useJsonDataStore } from "@/shared/stores";
+import type { StoryData, SupportedFileType } from "@/shared/types";
+
+import { saveEditableFile } from "@/features/recent-files/recent-files-storage";
+
+export const useOpenEditableFile = () => {
+  const setJsonData = useJsonDataStore((state) => state.setJson);
+  const navigate = useNavigate();
+
+  return useCallback(
+    (content: StoryData, name: string, fileType: SupportedFileType) => {
+      const record = saveEditableFile({
+        name: name.trim() || "Untitled",
+        fileType,
+        content,
+      });
+      setJsonData(record.content, record.name, record.id);
+      void navigate({
+        to: "/files/$fileId",
+        params: { fileId: record.id },
+      });
+      return record;
+    },
+    [navigate, setJsonData],
+  );
+};

--- a/src/shared/hooks/use-mobile.ts
+++ b/src/shared/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/src/shared/lib/convertors/from-twee.test.ts
+++ b/src/shared/lib/convertors/from-twee.test.ts
@@ -39,6 +39,20 @@ describe("parseTwee", () => {
     expect(cave?.content).toEqual(["The cave is silent."]);
   });
 
+  it("preserves Twee node position and size metadata", () => {
+    const story = parseTwee(
+      `:: Intro {"position":"25,50","size":"200,100"}
+Hello
+`,
+      { config: null },
+    );
+
+    expect(story.nodes[0]).toMatchObject({
+      position: { x: 25, y: 50 },
+      size: { width: 200, height: 100 },
+    });
+  });
+
   it("applies metadata sign matching when a config is provided", () => {
     const source = `:: Hero
 $hp 10

--- a/src/shared/lib/convertors/from-twee.ts
+++ b/src/shared/lib/convertors/from-twee.ts
@@ -13,6 +13,41 @@ export interface FromTweeOptions {
   config?: MetadataConfigTemplate | null;
 }
 
+interface TweeDeclarationMetadata {
+  position?: string;
+  size?: string;
+}
+
+const parseCoordinatePair = (value: string | undefined) => {
+  if (!value) return null;
+  const [first, second] = value.split(",").map((part) => Number(part.trim()));
+  if (!Number.isFinite(first) || !Number.isFinite(second)) return null;
+  return { first, second };
+};
+
+const parseDeclarationMetadata = (
+  declaration: string,
+): Pick<StoryNode, "position" | "size"> => {
+  const metadataStart = declaration.indexOf("{");
+  if (metadataStart === -1) return {};
+
+  try {
+    const metadata = JSON.parse(
+      declaration.slice(metadataStart),
+    ) as TweeDeclarationMetadata;
+    const position = parseCoordinatePair(metadata.position);
+    const size = parseCoordinatePair(metadata.size);
+    return {
+      ...(position
+        ? { position: { x: position.first, y: position.second } }
+        : {}),
+      ...(size ? { size: { width: size.first, height: size.second } } : {}),
+    };
+  } catch {
+    return {};
+  }
+};
+
 export const parseTwee = (
   source: string,
   options: FromTweeOptions = {},
@@ -52,8 +87,10 @@ export const parseTwee = (
       const declaration = line.slice(2).trim();
       const declareName = declaration.split("[")[0];
       const name = declareName.split("{")[0].trim();
+      const layout = parseDeclarationMetadata(declaration);
       currentNode = {
         name,
+        ...layout,
         metadata: seedMetadataDefaults(config),
         choices: [],
         content: [],

--- a/src/shared/lib/editable-files-storage.ts
+++ b/src/shared/lib/editable-files-storage.ts
@@ -1,0 +1,133 @@
+import { STORAGE_EVENT } from "@/shared/hooks";
+import type { StoryData, SupportedFileType } from "@/shared/types";
+
+export interface EditableFileRecord {
+  id: string;
+  name: string;
+  fileType: SupportedFileType;
+  content: StoryData;
+  updatedAt: number;
+}
+
+export interface EditableFileDraft {
+  id?: string;
+  name: string;
+  fileType: SupportedFileType;
+  content: StoryData;
+}
+
+interface StorageOptions {
+  storage?: Storage;
+  now?: () => number;
+  createId?: () => string;
+}
+
+export const EDITABLE_FILES_STORAGE_KEY = "editableFiles";
+
+const defaultNow = () => Date.now();
+
+const createEditableFileId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+const getStorage = (storage?: Storage) => storage ?? localStorage;
+
+const readFiles = (storage: Storage): EditableFileRecord[] => {
+  const raw = storage.getItem(EDITABLE_FILES_STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as EditableFileRecord[]) : [];
+  } catch {
+    storage.removeItem(EDITABLE_FILES_STORAGE_KEY);
+    return [];
+  }
+};
+
+const notifyStorageChange = (files: EditableFileRecord[]) => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(STORAGE_EVENT, {
+      detail: { key: EDITABLE_FILES_STORAGE_KEY, newValue: files },
+    }),
+  );
+};
+
+const writeFiles = (storage: Storage, files: EditableFileRecord[]) => {
+  storage.setItem(EDITABLE_FILES_STORAGE_KEY, JSON.stringify(files));
+  notifyStorageChange(files);
+};
+
+const sortNewestFirst = (files: EditableFileRecord[]) =>
+  [...files].sort((a, b) => b.updatedAt - a.updatedAt);
+
+export const listEditableFiles = (
+  options: Pick<StorageOptions, "storage"> = {},
+): EditableFileRecord[] =>
+  sortNewestFirst(readFiles(getStorage(options.storage)));
+
+export const getEditableFile = (
+  id: string,
+  options: Pick<StorageOptions, "storage"> = {},
+): EditableFileRecord | null =>
+  readFiles(getStorage(options.storage)).find((file) => file.id === id) ?? null;
+
+export const searchEditableFiles = (
+  query: string,
+  options: Pick<StorageOptions, "storage"> = {},
+): EditableFileRecord[] => {
+  const normalizedQuery = query.trim().toLowerCase();
+  const files = listEditableFiles(options);
+  if (!normalizedQuery) return files;
+  return files.filter((file) => {
+    const searchable = [file.name, file.content.title, file.fileType]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return searchable.includes(normalizedQuery);
+  });
+};
+
+export const saveEditableFile = (
+  draft: EditableFileDraft,
+  options: StorageOptions = {},
+): EditableFileRecord => {
+  const storage = getStorage(options.storage);
+  const files = readFiles(storage);
+  const record: EditableFileRecord = {
+    id: draft.id ?? options.createId?.() ?? createEditableFileId(),
+    name: draft.name,
+    fileType: draft.fileType,
+    content: draft.content,
+    updatedAt: options.now?.() ?? defaultNow(),
+  };
+  writeFiles(
+    storage,
+    sortNewestFirst([
+      record,
+      ...files.filter((file) => file.id !== record.id),
+    ]),
+  );
+  return record;
+};
+
+export const updateEditableFileContent = (
+  id: string,
+  content: StoryData,
+  options: Omit<StorageOptions, "createId"> = {},
+) => {
+  const storage = getStorage(options.storage);
+  const files = readFiles(storage);
+  const updatedAt = options.now?.() ?? defaultNow();
+  writeFiles(
+    storage,
+    sortNewestFirst(
+      files.map((file) =>
+        file.id === id ? { ...file, content, updatedAt } : file,
+      ),
+    ),
+  );
+};

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,2 +1,3 @@
 export { cn } from "@/shared/lib/cn";
 export * from "@/shared/lib/convertors";
+export * from "@/shared/lib/editable-files-storage";

--- a/src/shared/stores/json-data-store.test.ts
+++ b/src/shared/stores/json-data-store.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { getEditableFile, saveEditableFile } from "@/features/recent-files";
 import { useJsonDataStore } from "@/shared/stores/json-data-store";
 import type { StoryData } from "@/shared/types";
 
@@ -57,5 +58,26 @@ describe("useJsonDataStore", () => {
     expect(intro?.content).toEqual(["Updated"]);
     expect(intro?.metadata).toEqual({ visited: true });
     expect(outro?.content).toEqual(["Bye"]);
+  });
+
+  it("persists node edits into the active editable file", () => {
+    saveEditableFile(
+      { name: "demo", fileType: "twee", content: sample },
+      { createId: () => "demo-id" },
+    );
+    useJsonDataStore.getState().setJson(sample, "demo", "demo-id");
+
+    useJsonDataStore.getState().setNode({
+      name: "Intro",
+      content: ["Stored edit"],
+      choices: [],
+      metadata: { visited: true },
+    });
+
+    expect(
+      getEditableFile("demo-id")?.content.nodes.find(
+        (node) => node.name === "Intro",
+      )?.content,
+    ).toEqual(["Stored edit"]);
   });
 });

--- a/src/shared/stores/json-data-store.ts
+++ b/src/shared/stores/json-data-store.ts
@@ -1,12 +1,18 @@
 import { create } from "zustand";
 
+import { updateEditableFileContent } from "@/shared/lib/editable-files-storage";
 import type { StoryData, StoryNode } from "@/shared/types";
 
 export interface JsonDataState {
   name: string;
+  activeFileId: string | null;
   content: StoryData;
   isLoading: boolean;
-  setJson: (newJson: StoryData, newName: string) => void;
+  setJson: (
+    newJson: StoryData,
+    newName: string,
+    activeFileId?: string | null,
+  ) => void;
   setNode: (newNode: StoryNode) => void;
   setLoading: (isLoading: boolean) => void;
   reset: () => void;
@@ -16,19 +22,41 @@ const emptyContent: StoryData = { nodes: [], start: null, title: null };
 
 export const useJsonDataStore = create<JsonDataState>((set) => ({
   name: "",
+  activeFileId: null,
   content: emptyContent,
   isLoading: false,
-  setJson: (newJson, newName) =>
-    set({ name: newName, content: newJson, isLoading: false }),
+  setJson: (newJson, newName, activeFileId = null) =>
+    set({
+      name: newName,
+      activeFileId,
+      content: newJson,
+      isLoading: false,
+    }),
   setNode: (newNode) =>
     set((state) => ({
-      content: {
+      content: persistActiveFileContent(state.activeFileId, {
         ...state.content,
         nodes: state.content.nodes.map((node) =>
           node.name === newNode.name ? newNode : node,
         ),
-      },
+      }),
     })),
   setLoading: (isLoading) => set({ isLoading }),
-  reset: () => set({ name: "", content: emptyContent, isLoading: false }),
+  reset: () =>
+    set({
+      name: "",
+      activeFileId: null,
+      content: emptyContent,
+      isLoading: false,
+    }),
 }));
+
+const persistActiveFileContent = (
+  activeFileId: string | null,
+  content: StoryData,
+) => {
+  if (activeFileId) {
+    updateEditableFileContent(activeFileId, content);
+  }
+  return content;
+};

--- a/src/shared/types/node.ts
+++ b/src/shared/types/node.ts
@@ -2,6 +2,14 @@ import type { Choice } from "@/shared/types/choice";
 
 export interface StoryNode {
   name: string;
+  position?: {
+    x: number;
+    y: number;
+  };
+  size?: {
+    width: number;
+    height: number;
+  };
   metadata: {
     [key: string]: number | boolean;
   };

--- a/src/shared/ui/sheet.tsx
+++ b/src/shared/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+
+import { cn } from "@/shared/lib/cn"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/shared/ui/sidebar.tsx
+++ b/src/shared/ui/sidebar.tsx
@@ -1,0 +1,726 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { PanelLeftIcon } from "lucide-react"
+import { Slot } from "@radix-ui/react-slot"
+
+import { useIsMobile } from "@/shared/hooks/use-mobile"
+import { cn } from "@/shared/lib/cn"
+import { Button } from "@/shared/ui/button"
+import { Input } from "@/shared/ui/input"
+import { Separator } from "@/shared/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/shared/ui/sheet"
+import { Skeleton } from "@/shared/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/shared/ui/tooltip"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen)
+  const open = openProp ?? _open
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value
+      if (setOpenProp) {
+        setOpenProp(openState)
+      } else {
+        _setOpen(openState)
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+    },
+    [setOpenProp, open]
+  )
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed"
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  )
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left"
+            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  isActive?: boolean
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot : "button"
+  const { isMobile, state } = useSidebar()
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+
+  if (!tooltip) {
+    return button
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  showOnHover?: boolean
+}) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
+        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  }, [])
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+  size?: "sm" | "md"
+  isActive?: boolean
+}) {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/src/shared/ui/skeleton.tsx
+++ b/src/shared/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/shared/lib/cn"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -34,6 +34,14 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
 }
 
 :root {
@@ -75,6 +83,14 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+  --sidebar: var(--card);
+  --sidebar-foreground: var(--card-foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent);
+  --sidebar-accent-foreground: var(--accent-foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
 }
 
 @layer base {
@@ -141,4 +157,15 @@
   padding-right: 10px;
   text-align: right;
   animation: rotate-words 6s infinite;
+}
+
+.dark {
+  --sidebar: hsl(240 5.9% 10%);
+  --sidebar-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-primary: hsl(224.3 76.3% 48%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(240 3.7% 15.9%);
+  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -96,7 +96,7 @@
   }
 }
 
-.draggable {
+.electron-titlebar-drag-region {
   -webkit-app-region: drag;
   background: #3d3d3d;
   width: 100vw;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -33,3 +33,17 @@ if (typeof window !== "undefined" && !window.ResizeObserver) {
   window.ResizeObserver =
     ResizeObserverStub as unknown as typeof ResizeObserver;
 }
+
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = (query) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add TanStack Router routes for the upload home page and editable file viewer.
- Persist uploaded editable files in localStorage and keep node edits synced to the active file record.
- Replace the custom recent-files rail with the shadcn `Sidebar` pattern, including a collapsible icon rail, `SidebarTrigger`, `SidebarRail`, search, and file menu links.
- Route the demo file through the same editable-file history flow and prevent empty-title Markdown uploads.
- Hide only the Electron titlebar from web view and preserve Twee graph positions in the dialog viewer.
- Fix React Flow rendering by avoiding `.draggable` CSS collisions, using dark React Flow node styling, and not forcing Twine sizes onto default nodes.

## Verification
- `pnpm test src/app/app.test.tsx && pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- Manual preview walkthrough on the latest production build: verified the shadcn sidebar layout, collapse/expand icon rail, sidebar search, upload to `/files/<id>`, and sidebar persistence on the file page.

[shadcn_collapsible_sidebar_demo.mp4](https://cursor.com/agents/bc-13c66f80-2c50-423a-bdf1-437901d32b63/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshadcn_collapsible_sidebar_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13c66f80-2c50-423a-bdf1-437901d32b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13c66f80-2c50-423a-bdf1-437901d32b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

