### PR TITLE
Add node option destination selector

### DIFF
--- a/src/features/dialog-viewer/dialog-viewer.tsx
+++ b/src/features/dialog-viewer/dialog-viewer.tsx
@@ -5,8 +5,9 @@ import {
   useNodesState,
   type Edge,
   type Node,
+  type ReactFlowInstance,
 } from "@xyflow/react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useJsonDataStore, useNodeStore } from "@/shared/stores";
 import {
@@ -17,9 +18,15 @@ import {
 const isElectronRenderer = () =>
   typeof window !== "undefined" && Boolean(window.ipcRenderer);
 
+const PREVIEW_NODE_CLASS =
+  "dialog-node-preview ring-2 ring-primary ring-offset-2 ring-offset-background";
+
 export const DialogViewer = () => {
   const content = useJsonDataStore((state) => state.content);
   const setSelectedNode = useNodeStore((state) => state.setNode);
+  const previewNodeName = useNodeStore((state) => state.previewNodeName);
+  const flowInstanceRef =
+    useRef<ReactFlowInstance<Node<DialogNodeData>, Edge> | null>(null);
 
   const initial = useMemo(
     () => buildDialogGraph(content),
@@ -30,6 +37,21 @@ export const DialogViewer = () => {
     initial.nodes,
   );
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(initial.edges);
+  const displayedNodes = useMemo(
+    () =>
+      nodes.map((node) =>
+        node.id === previewNodeName
+          ? {
+              ...node,
+              selected: true,
+              className: [node.className, PREVIEW_NODE_CLASS]
+                .filter(Boolean)
+                .join(" "),
+            }
+          : node,
+      ),
+    [nodes, previewNodeName],
+  );
 
   const onLayout = useCallback(() => {
     const updated = buildDialogGraph(content);
@@ -43,6 +65,17 @@ export const DialogViewer = () => {
     onLayout();
   }, [onLayout]);
 
+  useEffect(() => {
+    if (!previewNodeName || !flowInstanceRef.current) return;
+    if (!nodes.some((node) => node.id === previewNodeName)) return;
+
+    void flowInstanceRef.current.fitView({
+      nodes: [{ id: previewNodeName }],
+      duration: 250,
+      padding: 0.6,
+    });
+  }, [nodes, previewNodeName]);
+
   return (
     <div
       aria-label="Dialog flow chart"
@@ -52,13 +85,16 @@ export const DialogViewer = () => {
       <ReactFlow
         fitView
         colorMode="dark"
-        nodes={nodes}
+        nodes={displayedNodes}
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onNodeClick={(_e, node) => setSelectedNode(node.data.metadata)}
         connectionLineType={ConnectionLineType.Step}
-        onInit={onLayout}
+        onInit={(instance) => {
+          flowInstanceRef.current = instance;
+          onLayout();
+        }}
       />
     </div>
   );

--- a/src/features/node-editor/node-editor.component.test.tsx
+++ b/src/features/node-editor/node-editor.component.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useJsonDataStore, useNodeStore } from "@/shared/stores";
+import type { StoryData } from "@/shared/types";
+
+import { DialogViewer } from "@/features/dialog-viewer";
+import { NodeEditor } from "@/features/node-editor/node-editor";
+
+const { flowInstance, reactFlow } = vi.hoisted(() => ({
+  flowInstance: {
+    fitView: vi.fn(),
+  },
+  reactFlow: vi.fn(() => <div data-testid="react-flow" />),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  ConnectionLineType: { Step: "step" },
+  ReactFlow: reactFlow,
+  useEdgesState: <T,>(initial: T[]) => [initial, vi.fn(), vi.fn()],
+  useNodesState: <T,>(initial: T[]) => [initial, vi.fn(), vi.fn()],
+}));
+
+const story: StoryData = {
+  title: "Demo",
+  start: "Intro",
+  nodes: [
+    {
+      name: "Intro",
+      position: { x: 0, y: 0 },
+      metadata: {},
+      content: ["Hi"],
+      choices: [{ text: "Next", destination: "Middle" }],
+    },
+    {
+      name: "Middle",
+      position: { x: 200, y: 0 },
+      metadata: {},
+      content: ["Middle"],
+      choices: [],
+    },
+    {
+      name: "Outro",
+      position: { x: 400, y: 0 },
+      metadata: {},
+      content: ["Bye"],
+      choices: [],
+    },
+  ],
+};
+
+const selectIntroNode = () => {
+  useJsonDataStore.getState().setJson(story, "demo");
+  useNodeStore.getState().setNode(story.nodes[0]);
+};
+
+const clearPreviewNode = () => {
+  const state = useNodeStore.getState() as ReturnType<
+    typeof useNodeStore.getState
+  > & {
+    setPreviewNodeName?: (nodeName: string | null) => void;
+  };
+  state.setPreviewNodeName?.(null);
+};
+
+describe("NodeEditor", () => {
+  afterEach(() => {
+    reactFlow.mockClear();
+    flowInstance.fitView.mockClear();
+    useJsonDataStore.getState().reset();
+    useNodeStore.getState().setNode(null);
+    clearPreviewNode();
+  });
+
+  it("updates a choice destination from the available story nodes", async () => {
+    const user = userEvent.setup();
+    selectIntroNode();
+
+    render(<NodeEditor />);
+
+    await user.click(
+      screen.getByRole("combobox", { name: /destination for option next/i }),
+    );
+    await user.click(screen.getByRole("option", { name: "Outro" }));
+    await user.click(screen.getByRole("button", { name: /update node/i }));
+
+    expect(
+      useJsonDataStore
+        .getState()
+        .content.nodes.find((node) => node.name === "Intro")?.choices[0]
+        ?.destination,
+    ).toBe("Outro");
+  });
+
+  it("highlights and focuses the destination node while an option is hovered", async () => {
+    const user = userEvent.setup();
+    selectIntroNode();
+
+    render(
+      <>
+        <DialogViewer />
+        <NodeEditor />
+      </>,
+    );
+
+    const latestReactFlowProps = () =>
+      reactFlow.mock.calls.at(-1)?.[0] as
+        | {
+            nodes: Array<{
+              id: string;
+              selected?: boolean;
+              className?: string;
+            }>;
+            onInit?: (instance: typeof flowInstance) => void;
+          }
+        | undefined;
+
+    latestReactFlowProps()?.onInit?.(flowInstance);
+
+    await user.click(
+      screen.getByRole("combobox", { name: /destination for option next/i }),
+    );
+    await user.hover(screen.getByRole("option", { name: "Outro" }));
+
+    await waitFor(() => {
+      expect(flowInstance.fitView).toHaveBeenCalledWith({
+        nodes: [{ id: "Outro" }],
+        duration: 250,
+        padding: 0.6,
+      });
+    });
+
+    await waitFor(() => {
+      const outro = latestReactFlowProps()?.nodes.find(
+        (node) => node.id === "Outro",
+      );
+      expect(outro).toEqual(
+        expect.objectContaining({
+          selected: true,
+          className: expect.stringContaining("dialog-node-preview"),
+        }),
+      );
+    });
+  });
+});

--- a/src/features/node-editor/node-editor.component.test.tsx
+++ b/src/features/node-editor/node-editor.component.test.tsx
@@ -12,7 +12,7 @@ const { flowInstance, reactFlow } = vi.hoisted(() => ({
   flowInstance: {
     fitView: vi.fn(),
   },
-  reactFlow: vi.fn(() => <div data-testid="react-flow" />),
+  reactFlow: vi.fn((_props: unknown) => <div data-testid="react-flow" />),
 }));
 
 vi.mock("@xyflow/react", () => ({

--- a/src/features/node-editor/node-editor.tsx
+++ b/src/features/node-editor/node-editor.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import {
+  Controller,
   FormProvider,
   useFieldArray,
   useForm,
@@ -17,6 +18,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/shared/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
 import { Textarea } from "@/shared/ui/textarea";
 
 import { NodeMetadataEditor } from "@/features/node-editor/node-metadata-editor";
@@ -28,7 +36,13 @@ interface StoryNodeForm extends Omit<StoryNode, "content"> {
 export const NodeEditor = () => {
   const node = useNodeStore((state) => state.node);
   const setNode = useNodeStore((state) => state.setNode);
+  const setPreviewNodeName = useNodeStore((state) => state.setPreviewNodeName);
+  const content = useJsonDataStore((state) => state.content);
   const setJsonNode = useJsonDataStore((state) => state.setNode);
+  const nodeNames = useMemo(
+    () => content.nodes.map((storyNode) => storyNode.name),
+    [content.nodes],
+  );
 
   const methods = useForm<StoryNodeForm>({
     defaultValues: {
@@ -65,9 +79,16 @@ export const NodeEditor = () => {
     }
   }, [node, methods]);
 
+  useEffect(() => () => setPreviewNodeName(null), [setPreviewNodeName]);
+
   if (!node) {
     return null;
   }
+
+  const getDestinationOptions = (destination: string) =>
+    destination && !nodeNames.includes(destination)
+      ? [destination, ...nodeNames]
+      : nodeNames;
 
   return (
     <FormProvider {...methods}>
@@ -93,9 +114,49 @@ export const NodeEditor = () => {
                   defaultValue={field.text}
                 />
                 <ArrowRight className="size-12 text-muted-foreground" />
-                <span className="text-xl font-semibold">
-                  {field.destination}
-                </span>
+                <Controller
+                  control={methods.control}
+                  name={`choices.${index}.destination`}
+                  render={({ field: destination }) => {
+                    const optionText =
+                      methods.watch(`choices.${index}.text`) || field.text;
+                    return (
+                      <Select
+                        value={destination.value}
+                        onValueChange={destination.onChange}
+                        onOpenChange={(open) => {
+                          if (!open) setPreviewNodeName(null);
+                        }}
+                      >
+                        <SelectTrigger
+                          aria-label={`Destination for option ${optionText}`}
+                          className="w-[180px]"
+                        >
+                          <SelectValue placeholder="Select node" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {getDestinationOptions(destination.value).map(
+                            (nodeName) => (
+                              <SelectItem
+                                key={nodeName}
+                                value={nodeName}
+                                onFocus={() => setPreviewNodeName(nodeName)}
+                                onMouseEnter={() =>
+                                  setPreviewNodeName(nodeName)
+                                }
+                                onPointerMove={() =>
+                                  setPreviewNodeName(nodeName)
+                                }
+                              >
+                                {nodeName}
+                              </SelectItem>
+                            ),
+                          )}
+                        </SelectContent>
+                      </Select>
+                    );
+                  }}
+                />
               </div>
             ))}
             <NodeMetadataEditor />
@@ -104,7 +165,10 @@ export const NodeEditor = () => {
             <Button
               type="button"
               variant="warning"
-              onClick={() => setNode(null)}
+              onClick={() => {
+                setPreviewNodeName(null);
+                setNode(null);
+              }}
             >
               Cancel
             </Button>

--- a/src/shared/stores/node-store.test.ts
+++ b/src/shared/stores/node-store.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { useNodeStore } from "@/shared/stores/node-store";
 
 describe("useNodeStore", () => {
-  beforeEach(() => useNodeStore.setState({ node: null }));
+  beforeEach(() => useNodeStore.setState({ node: null, previewNodeName: null }));
 
   it("starts with no selected node", () => {
     expect(useNodeStore.getState().node).toBeNull();
@@ -29,5 +29,13 @@ describe("useNodeStore", () => {
     });
     useNodeStore.getState().setNode(null);
     expect(useNodeStore.getState().node).toBeNull();
+  });
+
+  it("setPreviewNodeName updates the previewed graph node", () => {
+    useNodeStore.getState().setPreviewNodeName("Outro");
+    expect(useNodeStore.getState().previewNodeName).toBe("Outro");
+
+    useNodeStore.getState().setPreviewNodeName(null);
+    expect(useNodeStore.getState().previewNodeName).toBeNull();
   });
 });

--- a/src/shared/stores/node-store.ts
+++ b/src/shared/stores/node-store.ts
@@ -4,10 +4,14 @@ import type { StoryNode } from "@/shared/types";
 
 export interface NodeState {
   node: StoryNode | null;
+  previewNodeName: string | null;
   setNode: (newNode: StoryNode | null) => void;
+  setPreviewNodeName: (nodeName: string | null) => void;
 }
 
 export const useNodeStore = create<NodeState>((set) => ({
   node: null,
+  previewNodeName: null,
   setNode: (newNode) => set({ node: newNode }),
+  setPreviewNodeName: (nodeName) => set({ previewNodeName: nodeName }),
 }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough
[node_option_destination_selector_demo.mp4](https://cursor.com/agents/bc-93a3b623-2d0c-4f5f-b7a7-4d7ea8baec4d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnode_option_destination_selector_demo.mp4)
[Hovered destination highlights graph node](https://cursor.com/agents/bc-93a3b623-2d0c-4f5f-b7a7-4d7ea8baec4d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnode_option_hover_highlight.webp)

## Summary
- Add destination selects for node choices so option targets can be changed from existing story nodes.
- Preview hovered destination options by highlighting the corresponding graph node and fitting it into view.
- Cover the editor/store behavior with focused Vitest tests.

## Testing
- `pnpm test src/features/node-editor/node-editor.component.test.tsx` (red before implementation: destination combobox missing)
- `pnpm test src/features/node-editor/node-editor.component.test.tsx src/shared/stores/node-store.test.ts src/features/dialog-viewer/dialog-viewer.component.test.tsx`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Manual preview walkthrough using `pnpm preview --host 127.0.0.1`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93a3b623-2d0c-4f5f-b7a7-4d7ea8baec4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93a3b623-2d0c-4f5f-b7a7-4d7ea8baec4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

